### PR TITLE
Fix deprecated GitHub Actions versions in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install, build, and upload your site
-        uses: withastro/action@v0
+        uses: withastro/action@v3
         # with:
             # path: . # The root location of your Astro project inside the repository. (optional)
             # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this repository are documented here.
 
 ---
 
+## 2026-03-25 — CI/CD
+
+### Fixed
+
+- **Deprecated GitHub Actions versions** (`.github/workflows/deploy.yaml`)
+
+  Updated `actions/checkout` v3→v4, `withastro/action` v0→v3, and `actions/deploy-pages` v1→v4 to resolve deployment failure caused by deprecated `upload-artifact: v3` dependency.
+
+  **Branch:** `sre-claude-20260325_fix-deploy-workflow/1` | **PR:** #TBD
+
+---
+
 ## 2026-03-25 — Site Configuration
 
 ### Added


### PR DESCRIPTION
## Summary
- Updated `actions/checkout` v3 → v4
- Updated `withastro/action` v0 → v3
- Updated `actions/deploy-pages` v1 → v4
- Fixes deployment failure caused by deprecated `upload-artifact: v3` dependency

## Test plan
- [ ] Build passes with 0 errors (`npm run build`)
- [ ] Deploy workflow succeeds after merge
- [ ] CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)